### PR TITLE
Fix for error when no test_ methods in class

### DIFF
--- a/lib/Test/Class/Moose.pm
+++ b/lib/Test/Class/Moose.pm
@@ -179,7 +179,7 @@ sub runtests {
                     my $message =
                       "Skipping '$test_class': no test methods found";
                     $reporting_class->skipped($message);
-                    skip $message;
+                    SKIP:{ skip $message, 0; };
                     return;
                 }
                 my $start = Benchmark->new;


### PR DESCRIPTION
Fix for:

https://github.com/Ovid/test-class-moose/issues/3
