### PR TITLE
A better fix for failing when no test_ defined

### DIFF
--- a/lib/Test/Class/Moose.pm
+++ b/lib/Test/Class/Moose.pm
@@ -179,7 +179,7 @@ sub runtests {
                     my $message =
                       "Skipping '$test_class': no test methods found";
                     $reporting_class->skipped($message);
-                    SKIP:{ skip $message, 0; };
+                    $builder->plan( skip_all => $message);
                     return;
                 }
                 my $start = Benchmark->new;


### PR DESCRIPTION
https://github.com/Ovid/test-class-moose/issues/3

output after fix:

```
t/run.t .. 
1..2
# 
# Executing tests for My::Test::Class
# 
    1..0 # SKIP Skipping 'My::Test::Class': no test methods found
ok 1 # skip Skipping 'My::Test::Class': no test methods found
# 
# Executing tests for Test::Foo::Bar
# 
    1..1
    # Test::Foo::Bar->test_returnTrue()
        ok 1 - True returned
        1..1
    ok 1 - test_returnTrue
ok 2 - Test::Foo::Bar
ok
All tests successful.
Files=1, Tests=2,  1 wallclock secs ( 0.04 usr  0.01 sys +  0.67 cusr  0.04 csys =  0.76 CPU)
Result: PASS
```
