### PR TITLE
Harness environment awareness

### DIFF
--- a/lib/Test/Class/Moose/Config.pm
+++ b/lib/Test/Class/Moose/Config.pm
@@ -9,6 +9,13 @@ use namespace::autoclean;
 has 'show_timing' => (
     is  => 'ro',
     isa => 'Bool',
+    lazy => 1,
+    default => sub {
+        if ( $_[0]->use_environment and $ENV{HARNESS_IS_VERBOSE} ) {
+            return 1;
+        }
+        return;
+    },
 );
 
 has 'builder' => (
@@ -20,6 +27,18 @@ has 'builder' => (
 );
 
 has 'statistics' => (
+    is  => 'ro',
+    isa => 'Bool',
+    lazy => 1,
+    default => sub {
+        if ( $_[0]->use_environment and $ENV{HARNESS_IS_VERBOSE} ) {
+            return 1;
+        }
+        return;
+    },
+);
+
+has 'use_environment' => (
     is  => 'ro',
     isa => 'Bool',
 );
@@ -87,6 +106,10 @@ test class/test method to run.
 =head2 * C<statistics>
 
 Boolean. Will display number of classes, test methods and tests run.
+
+=head2 * C<use_environment>
+
+Boolean.  Sets show_timing and statistics to true if your test harness is running verbosely, false otherwise.
 
 =head2 C<builder>
 

--- a/t/environment.t
+++ b/t/environment.t
@@ -1,0 +1,58 @@
+#!/usr/bin/env perl
+use lib 'lib';
+use Test::Most;
+use Scalar::Util 'looks_like_number';
+use Test::Class::Moose::Load qw(t/lib);
+
+
+{
+    my $test_suite = Test::Class::Moose->new;
+    is ( $test_suite->test_configuration->show_timing, undef, 'show timing is undef by default' );
+    is ( $test_suite->test_configuration->statistics, undef, 'statistics is undef by default' );
+}
+
+{
+    my $test_suite = Test::Class::Moose->new(
+        show_timing => 1,
+        statistics  => 1,
+    );
+    is ( $test_suite->test_configuration->show_timing, 1, 'show timing can be set to 1' );
+    is ( $test_suite->test_configuration->statistics, 1, 'statistics can be set to 1' );
+}
+
+{
+    my $test_suite = Test::Class::Moose->new(
+        show_timing => 1,
+        statistics  => 1,
+    );
+    is ( $test_suite->test_configuration->show_timing, 1, 'show timing can be set to 1' );
+    is ( $test_suite->test_configuration->statistics, 1, 'statistics can be set to 1' );
+}
+
+{
+    local $ENV{HARNESS_IS_VERBOSE} = 1;
+    my $test_suite = Test::Class::Moose->new(
+        use_environment => 1,
+    );
+    is ( $test_suite->test_configuration->show_timing, 1, 'show timing set to 1 when harness is verbose' );
+    is ( $test_suite->test_configuration->statistics, 1, 'statistics set to 1 when harness is verbose' );
+
+    use Data::Dumper;
+#    warn( Dumper $test_suite->test_configuration->args );
+
+}
+
+{
+    local $ENV{HARNESS_IS_VERBOSE} = 0;
+    my $test_suite = Test::Class::Moose->new(
+        use_environment => 1,
+    );
+    is ( $test_suite->test_configuration->show_timing, undef, 'show timing set to undef when harness is not verbose' );
+    is ( $test_suite->test_configuration->statistics, undef, 'statistics set to undef when harness is not verbose' );
+}
+
+
+
+
+
+done_testing;


### PR DESCRIPTION
Add a configuration variable 'use_environment' that allows for printing of statistics and timings being dependent on harness verbosity levels.

Example:

t/blah.t:
    my $test_suite = Test::Class::Moose->new(
        use_environment => 1,
    );

prove -v t/blah.t  # shows statistics and timings
prove t/blah.t  # does not show statistics and timings
