### PR TITLE
Requires at least Moose 2.000

### DIFF
--- a/lib/Test/Class/Moose.pm
+++ b/lib/Test/Class/Moose.pm
@@ -3,7 +3,7 @@ package Test::Class::Moose;
 # ABSTRACT: Test::Class + Moose
 
 use 5.10.0;
-use Moose;
+use Moose 2.0000;
 use Carp;
 use List::Util qw(shuffle);
 use List::MoreUtils qw(uniq);


### PR DESCRIPTION
At least does not work under Moose 1.18. I randomly tested on a version of Perl that we don't use any more, that had an ancient version of Moose.
