### PR TITLE
Tag inheritance 

### DIFF
--- a/lib/Test/Class/Moose/TagRegistry.pm
+++ b/lib/Test/Class/Moose/TagRegistry.pm
@@ -6,6 +6,7 @@ use strict;
 use warnings;
 
 use Carp;
+use Class::MOP;
 
 my %BY_TAG;
 
@@ -74,9 +75,15 @@ sub method_has_tag {
 
     # avoid auto-vivication
     return if not exists $BY_TAG{$tag};
-    return if not exists $BY_TAG{$tag}{$test_class};
 
-    return exists $BY_TAG{$tag}{$test_class}{$method};
+    my $class_meta = Class::MOP::Class->initialize($test_class);
+    my $method_meta = $class_meta->find_method_by_name($method);
+    return if not $method_meta;
+
+    my $real_test_class = $method_meta->package_name();
+    return if not exists $BY_TAG{$tag}{$real_test_class};
+
+    return exists $BY_TAG{$tag}{$real_test_class}{$method};
 }
 
 1;

--- a/t/tags.t
+++ b/t/tags.t
@@ -18,7 +18,7 @@ my $test_suite = Test::Class::Moose->new(
 # this is the correct behavior.
 my %methods_for = (
     'TestsFor::Basic'           => [qw/test_me test_me_not_overridden test_this_baby/],
-    'TestsFor::Basic::Subclass' => [qw/test_this_should_be_run/],
+    'TestsFor::Basic::Subclass' => [qw/test_me_not_overridden test_this_should_be_run/],
 );
 my @test_classes = sort $test_suite->test_classes;
 
@@ -39,7 +39,6 @@ $test_suite = Test::Class::Moose->new(
     'TestsFor::Basic::Subclass' => [qw/
         test_a_method_with_no_tags
         test_me
-        test_me_not_overridden
         test_this_baby
         test_this_should_be_run
     /],


### PR DESCRIPTION
Kudos on Test::Class::Moose, it seems like the most promising development in Perl testing I've seen in a while.

Tags didn't quite work like I expected though. My set up looked something like this:

package Foo;

sub test_stuff : Tags(blah) {
...
}

package Foo::Subclass;

extends 'Foo';

sub test_other_stuff {
...
}

So then I tried to run the suite while excluding the "blah" tag, and was surprised to find that the Foo::Subclass->test_stuff test ran. In my opinion, if I don't override a method, the parent classes tags should still apply.

So what I propose, and what this patch implements, is that tags should persist to sub-classes when the method isn't overridden. So if a method is overridden, the tags have to specified there. And if it's not overridden the tags from the parent class still apply.

This patch modifies TagRegistry::method_has_tag, to search for the class that actually defines the method, and uses those tags. I didn't modify the other TagRegistry functions, they don't appear to be used anywhere. I don't mind updating them to keep them consistent, but I figured I'd make sure this concept wasn't DOA first.
