### PR TITLE
Add the dzil MetaJSON plugin

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -10,6 +10,7 @@ version = 0.41
 skip = Person
 skip = ^TestsFor
 [@Basic]
+[MetaJSON]
 [@Git]
 [PodWeaver]
 [Repository]


### PR DESCRIPTION
I wish this was part of @Basic, but it's not

This will let the Repository plugin add both the cloneable url and the web url for your repo to the META.json file, and MetaCPAN will take advantage of that.

You might also want to use MetaResources to set the bugtracker explicitly if you prefer GH to rt.cpan.org.
