### PR TITLE
Proof-of-concept for MooseX::Role::Parameterized support

### DIFF
--- a/t/taglib/TestsFor/Basic/ParameterizedRole.pm
+++ b/t/taglib/TestsFor/Basic/ParameterizedRole.pm
@@ -1,0 +1,26 @@
+package TestsFor::Basic::ParameterizedRole;
+
+use Class::Load qw/ try_load_class /;
+
+our $mrp_available;
+BEGIN { $mrp_available = try_load_class( 'MooseX::Role::Parameterized' ) }
+
+use Test::Class::Moose::Role parameterized => $mrp_available;
+
+if ( $mrp_available ) {
+    parameter( message => ( is => 'ro', default => "Picked up from role" ));
+    role( sub {
+        my $p = shift;
+
+        method(
+          test_in_a_parameterizedrole => sub {
+            pass $p->message;
+          }
+        );
+    })
+} else {
+    diag "MooseX::Role::Parameterized not available. Skipping this role";
+}
+
+
+1;

--- a/t/taglib/TestsFor/Basic/WithParameterizedRole.pm
+++ b/t/taglib/TestsFor/Basic/WithParameterizedRole.pm
@@ -1,0 +1,12 @@
+package TestsFor::Basic::WithParameterizedRole;
+use Test::Class::Moose;
+
+with 'TestsFor::Basic::ParameterizedRole' => {
+  message => "This is picked up from a parameterized role"
+};
+
+sub test_in_withparameterizedrole {
+  pass "Got here";
+}
+
+1;

--- a/t/tags.t
+++ b/t/tags.t
@@ -36,11 +36,12 @@ subtest 'Multiple included tags' => sub {
                   /
             ],
             'TestsFor::MultipleExclude' => [],
-	    'TestsFor::Basic::WithRole' => [
-		qw/
-		test_in_a_role_with_tags
-	       /	
-	    ],
+      'TestsFor::Basic::WithRole' => [
+    qw/
+    test_in_a_role_with_tags
+         /
+      ],
+      'TestsFor::Basic::WithParameterizedRole' => [],
         }
     );
 };
@@ -70,13 +71,18 @@ subtest 'Simple exluded tag' => sub {
                   test_87801_3
                   /
             ],
-	    'TestsFor::Basic::WithRole' => [
-		    qw/
-		    test_in_a_role
-		    test_in_a_role_with_tags
-		    test_in_withrole
-		    /
-	    ],
+      'TestsFor::Basic::WithRole' => [
+        qw/
+        test_in_a_role
+        test_in_a_role_with_tags
+        test_in_withrole
+        /
+      ],
+      'TestsFor::Basic::WithParameterizedRole' => [
+        $TestsFor::Basic::ParameterizedRole::mrp_available ?
+          'test_in_a_parameterizedrole' : (),
+        qw/test_in_withparameterizedrole/,
+      ],
         }
     );
 };
@@ -87,7 +93,8 @@ subtest 'Simple included tag' => sub {
         {   'TestsFor::Basic'           => [],
             'TestsFor::Basic::Subclass' => [qw/ test_augment /],
             'TestsFor::MultipleExclude' => [],
-	    'TestsFor::Basic::WithRole' => [],
+      'TestsFor::Basic::WithRole' => [],
+      'TestsFor::Basic::WithParameterizedRole' => [],
         }
     );
 };
@@ -104,7 +111,8 @@ subtest
         {   'TestsFor::Basic'           => [],
             'TestsFor::Basic::Subclass' => [],
             'TestsFor::MultipleExclude' => [qw/test_87801_3/],
-	    'TestsFor::Basic::WithRole' => [],
+      'TestsFor::Basic::WithRole' => [],
+      'TestsFor::Basic::WithParameterizedRole' => [],
         }
     );
   };


### PR DESCRIPTION
How would you feel about adding support for MooseX::Role::Parameterized? Maybe even like below? MRP support is the only show-stopper that prevents me from switching most of our test infrastructure over from Test::Able to Test::Class::Mose, so I am more than willing to curate this feature until it is release ready.

Most likely t/tags.t is not the best place to test that feature, but for a proof of concept this was the easiest to pull of. Please also ignore the white-space changes in this file, in the unlikely event you want to merge this feature as-is, I will correct those to match the projects style.
