### PR TITLE
Fix test failure line reporting with Role::Parallel

### DIFF
--- a/lib/Test/Class/Moose/Role/Parallel.pm
+++ b/lib/Test/Class/Moose/Role/Parallel.pm
@@ -34,6 +34,7 @@ around 'runtests' => sub {
     my $orig = shift;
     my $self = shift;
 
+    local $Test::Builder::Level = $Test::Builder::Level + 4;
     my $jobs = $self->test_configuration->jobs;
     return $self->$orig if $jobs < 2;
 


### PR DESCRIPTION
When using the parallel role, the runtest method gets wrapped with Moose
'around' resulting in roughly 4 levels of wrapped code.
Test::Builder needs to be told that the failure doesn't come from
Test::Class::Moose:Role::Parallel
