### PR TITLE
Add missing semicolon

### DIFF
--- a/lib/Test/Class/Moose/Tutorial.pm
+++ b/lib/Test/Class/Moose/Tutorial.pm
@@ -1,4 +1,4 @@
-package Test::Class::Moose::Tutorial
+package Test::Class::Moose::Tutorial;
 
 # ABSTRACT: A starting guide for Test::Class::Moose
 


### PR DESCRIPTION
With the $VERSION line that is automatically added by Dist::Zilla, this file no longer properly parses.

This may be the reason why the Test::Class::Moose::Tutorial link on metacpan goes to source, rather than rendered pod-to-html.
