### PR TITLE
When testing in parallel, ignore orphaned child pids.

### DIFF
--- a/lib/Test/Class/Moose/Executor/Parallel.pm
+++ b/lib/Test/Class/Moose/Executor/Parallel.pm
@@ -96,8 +96,9 @@ sub _test_class_is_parallelizable {
             $_,
             'noparallel'
         );
-    }
-    $self->_test_methods_for($test_class);
+      }
+
+      $self->_test_methods_for($test_class);
 }
 
 sub _run_test_classes_in_parallel {
@@ -131,10 +132,11 @@ sub _run_test_classes_in_parallel {
         # with Test2::AsyncSubtest::detach, and can potentially cascade into
         # all kinds of other problems during global destruction. i have no
         # idea how a grandchild death can end up running this code...
-        if ($$ == $child_pid) {
+        if ( $$ == $child_pid ) {
             $subtest->detach;
             $self->_fork_manager->finish( 0, \$class_report );
-        } else {
+        }
+        else {
             warn "Ignoring unknown child pid $$, did a grandchild pid die?";
         }
     }


### PR DESCRIPTION
Addresses issue #113 

When running prove without this fix, you get "Attempt to detach from wrong child" from Test2::Async while the test suite is running, and "Subtest can only be finished in the process/thread that created it" during destruction.

With this fix, we just get a new warning "Ignoring unknown child pid $pid, did a grandchild pid die?" and no other further complaints from Test2 or Test::Class::Moose.